### PR TITLE
renamed matching_keywords to package_keywords

### DIFF
--- a/Sources/SPISearchResult/SPISearchResult.swift
+++ b/Sources/SPISearchResult/SPISearchResult.swift
@@ -54,7 +54,7 @@ public struct SearchResult: Hashable, Identifiable, Codable {
         /// The swift package index identifier for the package.
         public let id: PackageId
         /// The keywords reported as matched for this package.
-        public let matching_keywords: [String]
+        public let package_keywords: [String]
         /// The summary description provided about the package.
         public let summary: String?
         /// The number of github stars reported for the package.
@@ -66,16 +66,16 @@ public struct SearchResult: Hashable, Identifiable, Codable {
         ///   - matching_keywords: The keywords that matched from the search
         ///   - summary: The summary about the package.
         ///   - stars: The number of github stars for the package.
-        public init(id: PackageId, matching_keywords: [String] = [], summary: String?, stars: Int) {
+        public init(id: PackageId, package_keywords: [String] = [], summary: String?, stars: Int) {
             self.id = id
-            self.matching_keywords = matching_keywords
+            self.package_keywords = package_keywords
             self.summary = summary
             self.stars = stars
         }
 
         enum CodingKeys: String, CodingKey {
             case id
-            case matching_keywords = "k"
+            case package_keywords = "k"
             case summary = "s"
             case stars = "x"
         }

--- a/Sources/SPISearchResult/SPISearchResult.swift
+++ b/Sources/SPISearchResult/SPISearchResult.swift
@@ -33,7 +33,7 @@ public struct SearchResult: Hashable, Identifiable, Codable {
     ///   - keywords: The keywords matched by the query terms.
     ///   - authors: The authors matched by the query terms.
     ///   - packages: The packages returned for the query terms.
-    public init(timestamp: Date, query: String, keywords: [String] = [], authors: [String] = [], packages: [Package]) {
+    public init(timestamp: Date, query: String, keywords: [String], authors: [String], packages: [Package]) {
         self.timestamp = timestamp
         self.query = query
         self.keywords = keywords
@@ -66,7 +66,7 @@ public struct SearchResult: Hashable, Identifiable, Codable {
         ///   - matching_keywords: The keywords that matched from the search
         ///   - summary: The summary about the package.
         ///   - stars: The number of github stars for the package.
-        public init(id: PackageId, package_keywords: [String] = [], summary: String?, stars: Int) {
+        public init(id: PackageId, package_keywords: [String], summary: String?, stars: Int) {
             self.id = id
             self.package_keywords = package_keywords
             self.summary = summary

--- a/Tests/SPISearchResultTests/SPISearchResultTests.swift
+++ b/Tests/SPISearchResultTests/SPISearchResultTests.swift
@@ -4,7 +4,7 @@ import SPISearchResult
 import XCTest
 
 final class SPISearchResultTests: XCTestCase {
-    let samplePackageResult = SearchResult.Package(id: .init(owner: "heckj", repository: "SPISearchResult"), matching_keywords: [], summary: "A package that defines the transfer objects to capture a collection of Search Results from Swift Package Index", stars: 1)
+    let samplePackageResult = SearchResult.Package(id: .init(owner: "heckj", repository: "SPISearchResult"), package_keywords: [], summary: "A package that defines the transfer objects to capture a collection of Search Results from Swift Package Index", stars: 1)
 
     let expectedJSONString = """
     {"id":{"o":"heckj","r":"SPISearchResult"},"k":[],"s":"A package that defines the transfer objects to capture a collection of Search Results from Swift Package Index","x":1}


### PR DESCRIPTION
In usage the keywords returned are the entire set available for the package, even though only matching values are shown